### PR TITLE
[WIP] Merge tag 'v6.4.5' of upstream Avalon

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ gem 'avalon-about', git: 'https://github.com/avalonmediasystem/avalon-about.git'
 gem 'bootstrap-toggle-rails', git: 'https://github.com/rkallensee/bootstrap-toggle-rails.git', tag: 'v2.2.1.0'
 gem 'bootstrap_form'
 gem 'speedy-af', '~> 0.1.1'
+gem 'recaptcha', require: 'recaptcha/rails'
 
 # Avalon Components
 gem 'avalon-workflow', git: "https://github.com/avalonmediasystem/avalon-workflow.git", tag: 'avalon-r6.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -638,6 +638,8 @@ GEM
       rdf (~> 2.1)
     rdf-xsd (2.2.0)
       rdf (~> 2.1)
+    recaptcha (4.12.0)
+      json
     redis (3.3.5)
     redis-actionpack (5.0.2)
       actionpack (>= 4.0, < 6)
@@ -936,6 +938,7 @@ DEPENDENCIES
   rb-readline
   rdf (~> 2.2)
   rdf-rdfxml
+  recaptcha
   redis-rails
   resque (~> 1.27.0)
   resque-scheduler (~> 4.3.0)

--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -255,7 +255,7 @@ class MediaObjectsController < ApplicationController
       end
 
       if error_messages.empty?
-        if api_params[:replace_master_files]
+        if api_params[:replace_masterfiles]
           old_ordered_master_files.each do |mf|
             p = MasterFile.find(mf)
             @media_object.master_files.delete(p)
@@ -272,9 +272,13 @@ class MediaObjectsController < ApplicationController
         if !@media_object.save
           error_messages += ['Failed to create media object:']+@media_object.errors.full_messages
           @media_object.destroy
-        elsif !!api_params[:publish]
-          @media_object.publish!('REST API')
-          @media_object.workflow.publish
+        else
+          if !!api_params[:publish]
+            @media_object.publish!('REST API')
+            @media_object.workflow.publish
+          else
+            @media_object.publish!('')
+          end
         end
       end
     end
@@ -611,6 +615,6 @@ class MediaObjectsController < ApplicationController
   end
 
   def api_params
-    params.permit(:collection_id, :publish, :import_bib_record, :replace_master_files)
+    params.permit(:collection_id, :publish, :import_bib_record, :replace_masterfiles)
   end
 end

--- a/app/jobs/bulk_action_jobs.rb
+++ b/app/jobs/bulk_action_jobs.rb
@@ -162,6 +162,8 @@ module BulkActionJobs
     end
   end
 
+  require 'avalon/intercom'
+
   class IntercomPush < ActiveJob::Base
     def perform documents, user_key, params
       errors = []

--- a/app/jobs/cleanup_working_file_job.rb
+++ b/app/jobs/cleanup_working_file_job.rb
@@ -15,7 +15,12 @@
 class CleanupWorkingFileJob < ActiveJob::Base
   def perform(masterfile_id)
     masterfile = MasterFile.find(masterfile_id)
-    path = masterfile.working_file_path
-    File.delete(path) if path.present? && File.exist?(path)
+    masterfile.working_file_path.map do |path|
+      parent_directory = File.dirname(path)
+      File.delete(path) if File.exist?(path)
+      Dir.delete(parent_directory) if Dir.exist?(parent_directory)
+    end
+    masterfile.working_file_path = nil
+    masterfile.save!
   end
 end

--- a/app/jobs/ingest_batch_status_email_jobs.rb
+++ b/app/jobs/ingest_batch_status_email_jobs.rb
@@ -24,7 +24,7 @@ module IngestBatchStatusEmailJobs
         # Get the entries for the batch and see if they all complete
         complete = true
         errors = false
-        BatchEntries.where(batch_registries_id: br.id).each do |entry|
+        br.batch_entries.each do |entry|
           complete = false unless entry.complete || entry.error
           errors = true if entry.error
         end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -219,7 +219,7 @@ class Ability
   end
 
   def is_member_of_any_collection?
-    @user.id.present? && Admin::Collection.where("inheritable_edit_access_person_ssim" => @user.user_key).first.present?
+    @user.id.present? && Admin::Collection.exists?("inheritable_edit_access_person_ssim" => @user.user_key)
   end
 
   def full_login?

--- a/app/models/avalon/rdf_vocab.rb
+++ b/app/models/avalon/rdf_vocab.rb
@@ -1,11 +1,11 @@
 # Copyright 2011-2018, The Trustees of Indiana University and Northwestern
 #   University.  Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
-# 
+#
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software distributed
 #   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 #   CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -35,6 +35,7 @@ module Avalon
     class MasterFile < RDF::StrictVocabulary("http://avalonmediasystem.org/rdf/vocab/master_file#")
       property :posterOffset,        "rdfs:isDefinedBy" => %(avr-master_file:).freeze, type: "rdfs:Class".freeze
       property :thumbnailOffset,     "rdfs:isDefinedBy" => %(avr-master_file:).freeze, type: "rdfs:Class".freeze
+      property :workingFilePath,     "rdfs:isDefinedBy" => %(avr-master_file:).freeze, type: "rdfs:Class".freeze
     end
 
     class Derivative < RDF::StrictVocabulary("http://avalonmediasystem.org/rdf/vocab/derivative#")

--- a/app/models/master_file.rb
+++ b/app/models/master_file.rb
@@ -121,6 +121,9 @@ class MasterFile < ActiveFedora::Base
     index.as :stored_sortable
   end
 
+  # For working file copy when Settings.matterhorn.media_path is set
+  property :working_file_path, predicate: Avalon::RDFVocab::MasterFile.workingFilePath, multiple: true
+
   validates :workflow_name, presence: true, inclusion: { in: proc { WORKFLOWS } }
   validates_each :date_digitized do |record, attr, value|
     unless value.nil?
@@ -178,8 +181,7 @@ class MasterFile < ActiveFedora::Base
   def setContent(file)
     case file
     when Hash #Multiple files for pre-transcoded derivatives
-      saveOriginal( (file.has_key?('quality-high') && File.file?( file['quality-high'] )) ? file['quality-high'] : (file.has_key?('quality-medium') && File.file?( file['quality-medium'] )) ? file['quality-medium'] : file.values[0] )
-      file.each_value {|f| f.close unless f.closed? }
+      saveDerivativesHash(file)
     when ActionDispatch::Http::UploadedFile #Web upload
       saveOriginal(file, file.original_filename)
     when URI, Addressable::URI
@@ -191,7 +193,7 @@ class MasterFile < ActiveFedora::Base
         self.file_size = FileLocator::S3File.new(file).object.size
       end
     else #Batch
-      saveOriginal(file)
+      saveOriginal(file, File.basename(file.path))
     end
     reloadTechnicalMetadata!
   end
@@ -260,14 +262,22 @@ class MasterFile < ActiveFedora::Base
 
     #Build hash for single file skip transcoding
     if !file.is_a?(Hash) && (self.workflow_name == 'avalon-skip-transcoding' || self.workflow_name == 'avalon-skip-transcoding-audio')
-      file = {'quality-high' => FileLocator.new(file_location).attachment}
+      if working_file_path.present?
+        file = {'quality-high' => FileLocator.new(working_file_path.first).attachment}
+      else
+        file = {'quality-high' => FileLocator.new(file_location).attachment}
+      end
     end
 
     input = if file.is_a? Hash
       file_dup = file.dup
       file_dup.each_pair {|quality, f| file_dup[quality] = FileLocator.new(f.to_path).uri.to_s }
     else
-      matterhorn_path
+      if working_file_path.present?
+        FileLocator.new(working_file_path.first).uri.to_s
+      else
+        FileLocator.new(file_location).uri.to_s
+      end
     end
 
     ActiveEncodeJob::Create.perform_later(self.id, input, {preset: self.workflow_name})
@@ -527,11 +537,23 @@ class MasterFile < ActiveFedora::Base
     end
   end
 
-  def working_file_path
-    path = nil
-    config_path = Rails.application.secrets.matterhorn_client_media_path
-    path = File.join(config_path, File.basename(self.file_location)) if config_path.present? && File.directory?(config_path)
-    path
+  def create_working_file!(full_path)
+    working_path = MasterFile.calculate_working_file_path(full_path)
+    return unless working_path.present?
+
+    self.working_file_path = [working_path]
+    FileUtils.mkdir(File.dirname(working_path))
+    FileUtils.cp(full_path, working_path)
+    working_path
+  end
+
+  def self.calculate_working_file_path(old_path)
+    config_path = Settings.matterhorn.media_path
+    if config_path.present? && File.directory?(config_path)
+      File.join(config_path, SecureRandom.uuid, File.basename(old_path))
+    else
+      nil
+    end
   end
 
   protected
@@ -675,14 +697,26 @@ class MasterFile < ActiveFedora::Base
         realpath = path
       end
 
-      self.file_location = realpath
-      newpath = working_file_path
-      FileUtils.cp(realpath, newpath) unless newpath.blank?
+      create_working_file!(realpath)
     end
     self.file_location = realpath
     self.file_size = file.size.to_s
   ensure
     file.close
+  end
+
+  def saveDerivativesHash(derivative_hash)
+    usable_files = derivative_hash.select { |quality, file| File.file?(file) }
+    self.working_file_path = usable_files.values.collect { |file| create_working_file!(File.realpath(file)) }.compact
+
+    %w(quality-high quality-medium quality-low).each do |quality|
+      next unless usable_files.has_key?(quality)
+      self.file_location = File.realpath(usable_files[quality])
+      self.file_size = usable_files[quality].size.to_s
+      break
+    end
+  ensure
+    derivative_hash.values.map { |file| file.close }
   end
 
   def reloadTechnicalMetadata!

--- a/app/models/master_file.rb
+++ b/app/models/master_file.rb
@@ -548,7 +548,7 @@ class MasterFile < ActiveFedora::Base
   end
 
   def self.calculate_working_file_path(old_path)
-    config_path = Settings.matterhorn.media_path
+    config_path = Rails.application.secrets.matterhorn_client_media_path
     if config_path.present? && File.directory?(config_path)
       File.join(config_path, SecureRandom.uuid, File.basename(old_path))
     else

--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -26,9 +26,14 @@ Unless required by applicable law or agreed to in writing, software distributed
       <%= comment.text_field :name, label: 'Name' %>
       <%= comment.hidden_field :nickname %>
       <%= comment.email_field :email, label: 'Email address' %>
-      <%= comment.email_field :email_confirmation, label: 'Confirm email address' %> 
-      <%= comment.select :subject, @subjects, prompt: 'Select one' %>    
+      <%= comment.email_field :email_confirmation, label: 'Confirm email address' %>
+      <%= comment.select :subject, @subjects, prompt: 'Select one' %>
       <%= comment.text_area :comment, rows: 10 %>
+      <% if Settings.recaptcha.present?%>
+        <div class="form-group">
+          <%= recaptcha_tags %>
+        </div>
+      <% end %>
       <%= comment.primary "Submit comments" %>
     </fieldset>
   <% end %>

--- a/app/views/layouts/avalon.html.erb
+++ b/app/views/layouts/avalon.html.erb
@@ -35,6 +35,8 @@ Unless required by applicable law or agreed to in writing, software distributed
     <link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32" />
     <link rel="icon" type="image/png" href="/favicon-16x16.png" sizes="16x16" />
     <link rel="icon" type="image/png" href="/favicon-128.png" sizes="128x128" />
+    
+    <%= render "modules/google_analytics" %>
   </head>
 
   <body data-mountpoint="<%=root_path%>">

--- a/app/views/layouts/embed.html.erb
+++ b/app/views/layouts/embed.html.erb
@@ -30,6 +30,7 @@ Unless required by applicable law or agreed to in writing, software distributed
     <%= stylesheet_link_tag "application", media: "all" %>
     <%= yield :page_styles %>
     <%= yield :additional_head_content %>
+    <%= render "modules/google_analytics" %>
   </head>
 
   <body data-mountpoint="<%= root_path %>">

--- a/app/views/modules/_google_analytics.html.erb
+++ b/app/views/modules/_google_analytics.html.erb
@@ -1,0 +1,9 @@
+<% if Settings.google_analytics_tracking_id.present? %>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=<%= Settings.google_analytics_tracking_id %>"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', '<%= Settings.google_analytics_tracking_id %>');
+  </script>
+<% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,7 +8,7 @@ require 'resolv-replace'
 Bundler.require(*Rails.groups)
 
 module Avalon
-  VERSION = '6.4.3'
+  VERSION = '6.4.5'
 
   class Application < Rails::Application
     require 'avalon/configuration'

--- a/config/initializers/recaptcha.rb
+++ b/config/initializers/recaptcha.rb
@@ -1,0 +1,8 @@
+
+# config/initializers/recaptcha.rb
+if Settings.recaptcha.present?
+  Recaptcha.configure do |config|
+    config.site_key = Settings.recaptcha.site_key
+    config.secret_key = Settings.recaptcha.secret_key
+  end
+end

--- a/lib/avalon/batch/entry.rb
+++ b/lib/avalon/batch/entry.rb
@@ -204,6 +204,15 @@ module Avalon
           files = self.class.gatherFiles(file_spec[:file])
           self.class.attach_datastreams_to_master_file(master_file, file_spec[:file])
           master_file.setContent(files)
+
+          # Overwrite files hash with working file paths to pass to matterhorn
+          if files.is_a?(Hash) && master_file.working_file_path.present?
+            files.each do |quality, file|
+              working_path = master_file.working_file_path.find { |path| File.basename(file) == File.basename(path) }
+              files[quality] = File.new(working_path)
+            end
+          end
+
           master_file.absolute_location = file_spec[:absolute_location] if file_spec[:absolute_location].present?
           master_file.title = file_spec[:label] if file_spec[:label].present?
           master_file.poster_offset = file_spec[:offset] if file_spec[:offset].present?

--- a/lib/avalon/intercom.rb
+++ b/lib/avalon/intercom.rb
@@ -33,7 +33,7 @@ module Avalon
 
     def push_media_object(media_object, collection_id, include_structure = true)
       return { message: 'Avalon intercom target is not configured.' } unless @avalon.present?
-      return { message: 'You are not autorized to push to this collection.' } unless collection_valid? collection_id
+      return { message: 'You are not authorized to push to this collection.' } unless collection_valid? collection_id
       begin
         resp = RestClient::Request.execute(
           method: :post,

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -16,6 +16,10 @@ require 'rails_helper'
 
 describe ApplicationController do
   controller do
+    def index
+
+    end
+
     def create
       render nothing: true
     end
@@ -87,6 +91,20 @@ describe ApplicationController do
     it 'skips post requests' do
       post :create, id: 'avalon:1234'
       expect(response).not_to have_http_status(304)
+    end
+  end
+
+  describe "layout" do
+    render_views
+
+    it 'renders avalon layout' do
+      get :show, id: 'abc1234'
+      expect(response).to render_template("layouts/avalon")
+    end
+
+    it 'renders google analytics partial' do
+      get :show, id: 'abc1234'
+      expect(response).to render_template("modules/_google_analytics")
     end
   end
 end

--- a/spec/controllers/bookmarks_controller_spec.rb
+++ b/spec/controllers/bookmarks_controller_spec.rb
@@ -16,7 +16,14 @@ require 'rails_helper'
 require 'avalon/intercom'
 
 describe BookmarksController, type: :controller do
+  include ActiveJob::TestHelper
+
   render_views
+
+  around(:example) do |example|
+    # In Rails 5.1+ this can be restricted to whitelist jobs allowed to be performed
+    perform_enqueued_jobs { example.run }
+  end
 
   let!(:collection) { FactoryGirl.create(:collection) }
   let!(:media_objects) { [] }

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -259,7 +259,7 @@ describe Admin::CollectionsController, type: :controller do
       # allow(mock_email).to receive(:deliver_later)
       # expect(NotificationsMailer).to receive(:new_collection).and_return(mock_email)
       # FIXME: This delivers two instead of one for some reason
-      expect {post 'create', format:'json', admin_collection: {name: collection.name, description: collection.description, unit: collection.unit, managers: collection.managers}}.to change { ActionMailer::Base.deliveries.count }
+      expect {post 'create', format:'json', admin_collection: {name: collection.name, description: collection.description, unit: collection.unit, managers: collection.managers}}.to have_enqueued_job(ActionMailer::DeliveryJob).twice
       # post 'create', format:'json', admin_collection: {name: collection.name, description: collection.description, unit: collection.unit, managers: collection.managers}
     end
     it "should create a new collection" do
@@ -285,9 +285,7 @@ describe Admin::CollectionsController, type: :controller do
       # expect(mock_delay).to receive(:update_collection)
       @collection = FactoryGirl.create(:collection)
       # put 'update', id: @collection.id, admin_collection: {name: "#{@collection.name}-new", description: @collection.description, unit: @collection.unit}
-      # FIXME: This delivers two instead of one for some reason
-      expect {put 'update', id: @collection.id, admin_collection: {name: "#{@collection.name}-new", description: @collection.description, unit: @collection.unit}}.to change { ActionMailer::Base.deliveries.count }
-
+      expect {put 'update', id: @collection.id, admin_collection: {name: "#{@collection.name}-new", description: @collection.description, unit: @collection.unit}}.to have_enqueued_job(ActionMailer::DeliveryJob).once
     end
 
     context "update REST API" do

--- a/spec/controllers/master_files_controller_spec.rb
+++ b/spec/controllers/master_files_controller_spec.rb
@@ -15,13 +15,6 @@
 require 'rails_helper'
 
 describe MasterFilesController do
-  before do
-    ActiveJob::Base.queue_adapter = :test
-  end
-
-  after do
-    ActiveJob::Base.queue_adapter = :inline
-  end
 
   describe "#create" do
     let(:media_object) { FactoryGirl.create(:media_object) }
@@ -240,6 +233,8 @@ describe MasterFilesController do
                                      ordered_master_files: [master_file], master_file_ids: [master_file.id])
     end
 
+    render_views
+
     before do
       allow_any_instance_of(MasterFile).to receive(:media_object).and_return(media_object)
       allow_any_instance_of(MasterFile).to receive(:media_object_id).and_return(media_object.id)
@@ -248,6 +243,10 @@ describe MasterFilesController do
 
     it "renders the embed layout" do
       expect(get(:embed, id: master_file.id)).to render_template(layout: 'embed')
+    end
+
+    it "renders the Google Analytics partial" do
+      expect(get(:embed, id: master_file.id )).to render_template('modules/_google_analytics')
     end
 
     context 'with fedora 3 pid' do

--- a/spec/controllers/media_objects_controller_spec.rb
+++ b/spec/controllers/media_objects_controller_spec.rb
@@ -15,6 +15,8 @@
 require 'rails_helper'
 
 describe MediaObjectsController, type: :controller do
+  include ActiveJob::TestHelper
+
   render_views
 
   before(:each) do
@@ -130,7 +132,7 @@ describe MediaObjectsController, type: :controller do
       let(:target_link) { { link: 'http://link.to/media_object' } }
       let(:error_status) { { message: 'Not authorized', status: 401 } }
       let(:media_object_permission) { 'You do not have permission to push this media object.' }
-      let(:collection_permission) { 'You are not autorized to push to this collection.' }
+      let(:collection_permission) { 'You are not authorized to push to this collection.' }
       before do
         login_as(:administrator)
         session[:intercom_collections] = {}
@@ -404,16 +406,14 @@ describe MediaObjectsController, type: :controller do
           expect(media_object.master_files.to_a.size).to eq 2
         end
         it "should update the poster and thumbnail for its masterfile" do
-          ActiveJob::Base.queue_adapter = :test
           media_object = FactoryGirl.create(:media_object)
           put 'json_update', format: 'json', id: media_object.id, files: [master_file], collection_id: media_object.collection_id
           media_object.reload
           expect(media_object.master_files.to_a.size).to eq 1
           expect(ExtractStillJob).to have_been_enqueued.with(media_object.master_files.first.id,{type:'both',offset:2000})
-          ActiveJob::Base.queue_adapter = :inline
         end
         it "should delete existing master_files and add a new master_file to a media_object" do
-          put 'json_update', format: 'json', id: media_object.id, files: [master_file], collection_id: media_object.collection_id, replace_master_files: true
+          put 'json_update', format: 'json', id: media_object.id, files: [master_file], collection_id: media_object.collection_id, replace_masterfiles: true
           expect(JSON.parse(response.body)['id'].class).to eq String
           expect(JSON.parse(response.body)).not_to include('errors')
           media_object.reload
@@ -842,6 +842,11 @@ describe MediaObjectsController, type: :controller do
     let!(:collection) { FactoryGirl.create(:collection) }
     before(:each) do
       login_user collection.managers.first
+    end
+
+    around(:example) do |example|
+      # In Rails 5.1+ this can be restricted to whitelist jobs allowed to be performed
+      perform_enqueued_jobs { example.run }
     end
 
     it "should remove a MediaObject with a single MasterFiles" do

--- a/spec/integration/working_file_path_spec.rb
+++ b/spec/integration/working_file_path_spec.rb
@@ -1,0 +1,297 @@
+require 'rails_helper'
+
+# MasterFile#working_file_path has been a source of problems since it was introduced in 6.4.3
+# This spec file is meant to thoroughly test it in order to find any remaining bugs and to
+# ensure the intended functionality doesn't get broken accidentally in the future.
+#
+# Need to test all of the possiblilites:
+# batch ingest with single file
+# batch ingest with single file skip transcoding
+# batch ingest with pre-transcoded derivatives
+# web upload
+# web upload skip transcoding
+# web dropbox upload
+# web dropbox skip transcoding
+# Repeat all of these with and without media path set.
+#
+# Pre-existing tests that are related (or duplicative)
+# spec/models/master_file_spec.rb:262
+# spec/models/master_file_spec.rb:500
+# spec/lib/avalon/batch/entry_spec.rb:80
+#
+describe "MasterFile#working_file_path" do
+  let(:master_file) { FactoryGirl.build(:master_file) }
+  let(:media_object) { FactoryGirl.create(:media_object) }
+  let(:workflow) { 'avalon' }
+
+  context "with Settings.matterhorn.media_path set" do
+    let(:media_path) { Dir.mktmpdir }
+
+    around(:example) do |example|
+      begin
+        old_media_path = Settings.matterhorn.media_path
+        Settings.matterhorn.media_path = media_path
+
+        example.run
+
+        Settings.matterhorn.media_path = old_media_path
+      ensure
+        FileUtils.remove_entry media_path
+      end
+    end
+
+    describe '#calculate_working_file_path' do
+      let(:path1) { MasterFile.calculate_working_file_path('/dropbox/coll1/video.mp4') }
+      let(:path2) { MasterFile.calculate_working_file_path('/dropbox/coll2/video.mp4') }
+
+      it 'returns a working file path' do
+        expect(File.fnmatch("#{File.absolute_path(media_path)}/*/video.mp4", path1)).to be true
+      end
+
+      it 'creates a unique working_file_path for each file' do
+        expect(path1).not_to eq path2
+      end
+    end
+
+    it 'can recompute the working_file_path' do
+      file = fixture_file_upload('spec/fixtures/videoshort.mp4', 'video/mp4')
+      master_file.setContent(file)
+      original_path = master_file.working_file_path
+      master_file.save!
+      new_path = MasterFile.find(master_file.id).working_file_path
+      expect(original_path).to eq new_path
+    end
+
+    context "using web upload" do
+      let(:file) { fixture_file_upload('spec/fixtures/videoshort.mp4', 'video/mp4') }
+      let(:params) { { Filedata: [file], original: nil, workflow: workflow } }
+
+      it 'sends the working_file_path to matterhorn' do
+        MasterFileBuilder.build(media_object, params)
+        master_file = media_object.reload.master_files.first
+        expect(File.exists? master_file.working_file_path.first).to be true
+        input = FileLocator.new(master_file.working_file_path.first).uri.to_s
+        expect(ActiveEncodeJob::Create).to have_been_enqueued.with(master_file.id, input, {preset: workflow})
+      end
+
+      context "with skip transcoding" do
+        let(:workflow) { 'skip_transcoding' }
+
+        it 'sends the working_file_path to matterhorn' do
+          MasterFileBuilder.build(media_object, params)
+          master_file = media_object.reload.master_files.first
+          expect(File.exists? master_file.working_file_path.first).to be true
+          input = { "quality-high" => FileLocator.new(master_file.working_file_path.first).uri.to_s }
+          expect(ActiveEncodeJob::Create).to have_been_enqueued.with(master_file.id, input, {preset: 'avalon-skip-transcoding'})
+        end
+      end
+    end
+
+    context "using dropbox upload" do
+      let(:file) { fixture_file_upload('spec/fixtures/videoshort.mp4', 'video/mp4') }
+      let(:url) { Addressable::URI.convert_path(File.absolute_path(file.to_path)) }
+      let(:params) { { selected_files: { "0" => { url: url, file_name: 'videoshort.mp4' } }, workflow: workflow } }
+
+      it 'sends the working_file_path to matterhorn' do
+        MasterFileBuilder.build(media_object, params)
+        master_file = media_object.reload.master_files.first
+        expect(File.exists? master_file.working_file_path.first).to be true
+        input = FileLocator.new(master_file.working_file_path.first).uri.to_s
+        expect(ActiveEncodeJob::Create).to have_been_enqueued.with(master_file.id, input, {preset: workflow})
+      end
+
+      context "with skip transcoding" do
+        let(:workflow) { 'skip_transcoding' }
+
+        it 'sends the working_file_path to matterhorn' do
+          MasterFileBuilder.build(media_object, params)
+          master_file = media_object.reload.master_files.first
+          expect(File.exists? master_file.working_file_path.first).to be true
+          input = { "quality-high" => FileLocator.new(master_file.working_file_path.first).uri.to_s }
+          expect(ActiveEncodeJob::Create).to have_been_enqueued.with(master_file.id, input, {preset: 'avalon-skip-transcoding'})
+        end
+      end
+    end
+
+    context "using batch ingest" do
+      let(:file) { fixture_file_upload('spec/fixtures/videoshort.mp4', 'video/mp4') }
+      let(:collection) { FactoryGirl.build(:collection) }
+      let(:entry_fields) { { title: Faker::Lorem.sentence, date_issued: "#{DateTime.now.strftime('%F')}" } }
+      let(:entry_files) { [{ file: File.absolute_path(file), skip_transcoding: false }] }
+      let(:entry_opts) { {user_key: 'archivist1@example.org', collection: collection} }
+      let(:entry) { Avalon::Batch::Entry.new(entry_fields, entry_files, entry_opts, nil, nil) }
+
+      before do
+        allow(entry).to receive(:media_object).and_return(media_object)
+      end
+
+      it 'sends the working_file_path to matterhorn' do
+        entry.process!
+        master_file = media_object.reload.master_files.first
+        expect(File.exists? master_file.working_file_path.first).to be true
+        input = FileLocator.new(master_file.working_file_path.first).uri.to_s
+        expect(ActiveEncodeJob::Create).to have_been_enqueued.with(master_file.id, input, {preset: workflow})
+      end
+
+      context 'with skip transcoding' do
+        let(:entry_files) { [{ file: File.absolute_path(file), skip_transcoding: true }] }
+
+        it 'sends the working_file_path to matterhorn' do
+          entry.process!
+          master_file = media_object.reload.master_files.first
+          expect(File.exists? master_file.working_file_path.first).to be true
+          input = { "quality-high" => FileLocator.new(master_file.working_file_path.first).uri.to_s }
+          expect(ActiveEncodeJob::Create).to have_been_enqueued.with(master_file.id, input, {preset: 'avalon-skip-transcoding'})
+        end
+      end
+
+      context 'with pre-transcoded derivatives' do
+        let(:filename) {File.join(Rails.root, "spec/fixtures/videoshort.mp4")}
+        %w(low medium high).each do |quality|
+          let("filename_#{quality}".to_sym) {File.join(Rails.root, "spec/fixtures/videoshort.#{quality}.mp4")}
+        end
+        let(:derivative_paths) {[filename_low, filename_medium, filename_high]}
+        let(:derivative_hash) {{'quality-low' => File.new(filename_low), 'quality-medium' => File.new(filename_medium), 'quality-high' => File.new(filename_high)}}
+
+        let(:entry_files) { [{ file: filename, skip_transcoding: true }] }
+
+        let(:original_file_locator) { instance_double("FileLocator") }
+        before do
+          allow(FileLocator).to receive(:new).and_call_original
+          allow(FileLocator).to receive(:new).with(filename).and_return(original_file_locator)
+          allow(original_file_locator).to receive(:exist?).and_return(false)
+        end
+
+        # All derivatives are copied to a working path
+        # TODO: Ensure all working file copies are cleaned up by the background job
+        it 'sends the working_file_path to matterhorn' do
+          entry.process!
+          master_file = media_object.reload.master_files.first
+          working_file_path_high = master_file.working_file_path.find { |file| file.include? "high" }
+          working_file_path_medium = master_file.working_file_path.find { |file| file.include? "medium" }
+          working_file_path_low = master_file.working_file_path.find { |file| file.include? "low" }
+
+          [working_file_path_high, working_file_path_medium, working_file_path_low].each do |file|
+            expect(File.exists? file).to be true
+          end
+          input = { "quality-high" => FileLocator.new(working_file_path_high).uri.to_s,
+                    "quality-medium" => FileLocator.new(working_file_path_medium).uri.to_s,
+                    "quality-low" => FileLocator.new(working_file_path_low).uri.to_s }
+          expect(ActiveEncodeJob::Create).to have_been_enqueued.with(master_file.id, input, {preset: 'avalon-skip-transcoding'})
+        end
+      end
+    end
+  end
+
+  context "without Settings.matterhorn.media_path set" do
+    it 'returns blank' do
+      expect(master_file.working_file_path).to be_blank
+    end
+
+    context "using web upload" do
+      let(:file) { fixture_file_upload('spec/fixtures/videoshort.mp4', 'video/mp4') }
+      let(:params) { { Filedata: [file], original: nil, workflow: workflow } }
+
+      it 'sends the file_location to matterhorn' do
+        MasterFileBuilder.build(media_object, params)
+        master_file = media_object.reload.master_files.first
+        input = FileLocator.new(master_file.file_location).uri.to_s
+        expect(ActiveEncodeJob::Create).to have_been_enqueued.with(master_file.id, input, {preset: workflow})
+      end
+
+      context "with skip transcoding" do
+        let(:workflow) { 'skip_transcoding' }
+
+        it 'sends the file_location to matterhorn' do
+          MasterFileBuilder.build(media_object, params)
+          master_file = media_object.reload.master_files.first
+          input = { "quality-high" => FileLocator.new(master_file.file_location).uri.to_s }
+          expect(ActiveEncodeJob::Create).to have_been_enqueued.with(master_file.id, input, {preset: 'avalon-skip-transcoding'})
+        end
+      end
+    end
+
+    context "using dropbox upload" do
+      let(:file) { fixture_file_upload('spec/fixtures/videoshort.mp4', 'video/mp4') }
+      let(:url) { Addressable::URI.convert_path(File.absolute_path(file.to_path)) }
+      let(:params) { { selected_files: { "0" => { url: url, file_name: 'videoshort.mp4' } }, workflow: workflow } }
+
+      it 'sends the file_location to matterhorn' do
+        MasterFileBuilder.build(media_object, params)
+        master_file = media_object.reload.master_files.first
+        input = FileLocator.new(master_file.file_location).uri.to_s
+        expect(ActiveEncodeJob::Create).to have_been_enqueued.with(master_file.id, input, {preset: workflow})
+      end
+
+      context "with skip transcoding" do
+        let(:workflow) { 'skip_transcoding' }
+
+        it 'sends the file_location to matterhorn' do
+          MasterFileBuilder.build(media_object, params)
+          master_file = media_object.reload.master_files.first
+          input = { "quality-high" => FileLocator.new(master_file.file_location).uri.to_s }
+          expect(ActiveEncodeJob::Create).to have_been_enqueued.with(master_file.id, input, {preset: 'avalon-skip-transcoding'})
+        end
+      end
+    end
+
+    context "using batch ingest" do
+      let(:file) { fixture_file_upload('spec/fixtures/videoshort.mp4', 'video/mp4') }
+      let(:collection) { FactoryGirl.build(:collection) }
+      let(:entry_fields) { { title: Faker::Lorem.sentence, date_issued: "#{DateTime.now.strftime('%F')}" } }
+      let(:entry_files) { [{ file: File.absolute_path(file), skip_transcoding: false }] }
+      let(:entry_opts) { {user_key: 'archivist1@example.org', collection: collection} }
+      let(:entry) { Avalon::Batch::Entry.new(entry_fields, entry_files, entry_opts, nil, nil) }
+
+      before do
+        allow(entry).to receive(:media_object).and_return(media_object)
+      end
+
+      it 'sends the file_location to matterhorn' do
+        entry.process!
+        master_file = media_object.reload.master_files.first
+        input = FileLocator.new(master_file.file_location).uri.to_s
+        expect(ActiveEncodeJob::Create).to have_been_enqueued.with(master_file.id, input, {preset: workflow})
+      end
+
+      context 'with skip transcoding' do
+        let(:entry_files) { [{ file: File.absolute_path(file), skip_transcoding: true }] }
+
+        it 'sends the file_location to matterhorn' do
+          entry.process!
+          master_file = media_object.reload.master_files.first
+          input = { "quality-high" => FileLocator.new(master_file.file_location).uri.to_s }
+          expect(ActiveEncodeJob::Create).to have_been_enqueued.with(master_file.id, input, {preset: 'avalon-skip-transcoding'})
+        end
+      end
+
+      context 'with pre-transcoded derivatives' do
+        let(:filename) {File.join(Rails.root, "spec/fixtures/videoshort.mp4")}
+        %w(low medium high).each do |quality|
+          let("filename_#{quality}".to_sym) {File.join(Rails.root, "spec/fixtures/videoshort.#{quality}.mp4")}
+        end
+        let(:derivative_paths) {[filename_low, filename_medium, filename_high]}
+        let(:derivative_hash) {{'quality-low' => File.new(filename_low), 'quality-medium' => File.new(filename_medium), 'quality-high' => File.new(filename_high)}}
+
+        let(:entry_files) { [{ file: filename, skip_transcoding: true }] }
+
+        let(:original_file_locator) { instance_double("FileLocator") }
+        before do
+          allow(FileLocator).to receive(:new).and_call_original
+          allow(FileLocator).to receive(:new).with(filename).and_return(original_file_locator)
+          allow(original_file_locator).to receive(:exist?).and_return(false)
+        end
+
+        it 'sends the derivative locations to matterhorn' do
+          entry.process!
+          master_file = media_object.reload.master_files.first
+          input = {'quality-low' => Addressable::URI.convert_path(File.absolute_path(filename_low)).to_s,
+                   'quality-medium' => Addressable::URI.convert_path(File.absolute_path(filename_medium)).to_s,
+                   'quality-high' => Addressable::URI.convert_path(File.absolute_path(filename_high)).to_s
+                  }
+          expect(ActiveEncodeJob::Create).to have_been_enqueued.with(master_file.id, input, {preset: 'avalon-skip-transcoding'})
+        end
+      end
+    end
+  end
+end

--- a/spec/integration/working_file_path_spec.rb
+++ b/spec/integration/working_file_path_spec.rb
@@ -29,12 +29,12 @@ describe "MasterFile#working_file_path" do
 
     around(:example) do |example|
       begin
-        old_media_path = Settings.matterhorn.media_path
-        Settings.matterhorn.media_path = media_path
+        old_media_path = Rails.application.secrets.matterhorn_client_media_path
+        Rails.application.secrets.matterhorn_client_media_path = media_path
 
         example.run
 
-        Settings.matterhorn.media_path = old_media_path
+        Rails.application.secrets.matterhorn_client_media_path = old_media_path
       ensure
         FileUtils.remove_entry media_path
       end

--- a/spec/jobs/cleanup_working_files_spec.rb
+++ b/spec/jobs/cleanup_working_files_spec.rb
@@ -15,14 +15,19 @@
 require 'rails_helper'
 
 describe CleanupWorkingFileJob do
-  let(:working_file) {'/temp/working_file.mp4'}
-  let(:master_file) {instance_double('MasterFile')}
+  let(:working_file) { '/temp/working_file.mp4' }
+  let(:master_file) { FactoryGirl.build(:master_file, working_file_path: [working_file]) }
+
+  before do
+    allow(MasterFile).to receive(:find).and_return(master_file)
+    allow(File).to receive(:exist?).and_return(true)
+    allow(Dir).to receive(:exist?).and_return(true)
+  end
+
   describe "perform" do
     it 'calls file delete when there is file to cleanup' do
-      allow(MasterFile).to receive(:find).and_return(master_file)
-      allow(master_file).to receive(:working_file_path).and_return(working_file)
-      allow(File).to receive(:exist?).and_return(true)
       expect(File).to receive(:delete).with(working_file).once
+      expect(Dir).to receive(:delete).with(File.dirname(working_file)).once
       CleanupWorkingFileJob.perform_now('abc123')
     end
   end

--- a/spec/lib/avalon/intercom_spec.rb
+++ b/spec/lib/avalon/intercom_spec.rb
@@ -72,7 +72,7 @@ describe Avalon::Intercom do
 
     it "should respond to unpermitted collection with error" do
       response = intercom.push_media_object(media_object, 'invalid_collection', false)
-      expect(response[:message]).to eq('You are not autorized to push to this collection.')
+      expect(response[:message]).to eq('You are not authorized to push to this collection.')
     end
     it "should respond to unconfigured intercom with error" do
       Settings.intercom = {}

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -500,7 +500,6 @@ describe Admin::Collection do
   describe "reindex_members" do
     before do
       @collection = FactoryGirl.create(:collection, items: 3)
-      ActiveJob::Base.queue_adapter = :test
     end
     it 'should queue a reindex job for all member objects' do
       @collection.reindex_members {}

--- a/spec/models/master_file_spec.rb
+++ b/spec/models/master_file_spec.rb
@@ -347,7 +347,7 @@ describe MasterFile do
         end
 
         it "should copy an uploaded file to the media path" do
-          Settings.matterhorn.media_path = media_path
+          Rails.application.secrets.matterhorn_client_media_path = media_path
           expect(File.fnmatch("#{media_path}/*/#{original}", subject.working_file_path.first)).to be true
         end
         it "should not disappear after the post_processing_file_management executes" do
@@ -539,8 +539,7 @@ describe MasterFile do
       @old_path = Rails.application.secrets.matterhorn_client_media_path
       @old_strategy = Settings.master_file_management.strategy
       Settings.master_file_management.strategy = 'none'
-      Rails.application.secrets.matterhorn_client_media_path= working_dir
-      Settings.matterhorn.media_path = working_dir
+      Rails.application.secrets.matterhorn_client_media_path = working_dir
     end
 
     after do
@@ -561,7 +560,7 @@ describe MasterFile do
       it 'returns a path when the working directory is valid' do
         file = File.new(Rails.root.join('spec', 'fixtures', 'videoshort.mp4'))
         master_file.setContent(file)
-        expect(master_file.working_file_path.first).to include(Settings.matterhorn.media_path)
+        expect(master_file.working_file_path.first).to include(Rails.application.secrets.matterhorn_client_media_path)
       end
     end
   end

--- a/spec/models/master_file_spec.rb
+++ b/spec/models/master_file_spec.rb
@@ -141,7 +141,6 @@ describe MasterFile do
     let!(:master_file) { FactoryGirl.create(:master_file) }
     # let(:encode_job) { ActiveEncodeJob::Create.new(master_file.id, nil, {}) }
     before do
-      ActiveJob::Base.queue_adapter = :test
       # allow(ActiveEncodeJob::Create).to receive(:new).and_return(encode_job)
       # allow(encode_job).to receive(:perform)
     end
@@ -220,11 +219,9 @@ describe MasterFile do
 
     describe "update images" do
       before do
-        ActiveJob::Base.queue_adapter = :test
         MasterFile.set_callback(:save, :after, :update_stills_from_offset!)
       end
       after do
-        ActiveJob::Base.queue_adapter = :inline
         MasterFile.skip_callback(:save, :after, :update_stills_from_offset!)
       end
       it "should update on save" do
@@ -350,8 +347,8 @@ describe MasterFile do
         end
 
         it "should copy an uploaded file to the media path" do
-          Rails.application.secrets.matterhorn_client_media_path = media_path
-          expect(subject.working_file_path).to eq(File.join(media_path,original))
+          Settings.matterhorn.media_path = media_path
+          expect(File.fnmatch("#{media_path}/*/#{original}", subject.working_file_path.first)).to be true
         end
         it "should not disappear after the post_processing_file_management executes" do
           new_media_object.collection = collection
@@ -536,13 +533,14 @@ describe MasterFile do
 
   context 'with a working directory' do
     subject(:master_file) { FactoryGirl.create(:master_file) }
-    let(:working_dir) {'/path/to/working_dir/'}
+    let(:working_dir) { Dir.mktmpdir }
     before do
       ActiveJob::Base.queue_adapter = :test
       @old_path = Rails.application.secrets.matterhorn_client_media_path
       @old_strategy = Settings.master_file_management.strategy
       Settings.master_file_management.strategy = 'none'
       Rails.application.secrets.matterhorn_client_media_path= working_dir
+      Settings.matterhorn.media_path = working_dir
     end
 
     after do
@@ -556,13 +554,14 @@ describe MasterFile do
       end
     end
     describe '#working_file_path' do
-      it 'returns nil when the working directory is invalid' do
-        expect(master_file.working_file_path).to be_nil
+      it 'returns blank when the working directory is invalid' do
+        expect(master_file.working_file_path).to be_blank
       end
 
       it 'returns a path when the working directory is valid' do
-        allow(File).to receive(:directory?).and_return(true)
-        expect(master_file.working_file_path).to include(working_dir)
+        file = File.new(Rails.root.join('spec', 'fixtures', 'videoshort.mp4'))
+        master_file.setContent(file)
+        expect(master_file.working_file_path.first).to include(Settings.matterhorn.media_path)
       end
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -66,7 +66,7 @@ Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 # If you are not using ActiveRecord, you can remove this line.
 ActiveRecord::Migration.maintain_test_schema!
 
-ActiveJob::Base.queue_adapter = :inline
+ActiveJob::Base.queue_adapter = :test
 
 Shoulda::Matchers.configure do |config|
   config.integrate do |with|

--- a/spec/views/google_analytics_spec.rb
+++ b/spec/views/google_analytics_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+describe "modules/_google_analytics.html.erb", type: :view do
+  context "Google Analytics is configured" do
+    before do
+      Settings.google_analytics_tracking_id = "arandomid"
+    end
+
+    it 'includes GA code' do
+      render
+      expect(rendered).to have_selector(:css, "script[src='https://www.googletagmanager.com/gtag/js?id=arandomid']", visible: false)
+    end
+  end
+
+  context "Google Analytics is not configured" do
+    before do
+      Settings.google_analytics_tracking_id = nil
+    end
+
+    it 'does not include GA code' do
+      render
+      expect(rendered).not_to have_selector(:css, "script[src='https://www.googletagmanager.com/gtag/js?id=arandomid']", visible: false)
+    end
+  end
+end


### PR DESCRIPTION
Fixes #587 ; 

Merge tag 'v6.4.5' of https://github.com/avalonmediasystem/avalon into avalon-6 (U of A v6.4.3.20190924.uofa) and cleanup merge conflicts

Adds:
* Merge upstream changes from tag `v6.4.5`
* Address merge conflicts with local code changes (see CHANGELOG.md)

Cleanup after merge of v6.4.5
* Align with work done at UAL with respect to PR #379, #396, #283 (Matterhorn client/server directory changes by UAL)

